### PR TITLE
Swift 2.1 compatibility & typo fix

### DIFF
--- a/Example/CustomActionControllers/Skype.swift
+++ b/Example/CustomActionControllers/Skype.swift
@@ -214,7 +214,7 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
     
     private func startAnimation() {
         if displayLink == nil {
-            self.displayLink = CADisplayLink(target: self, selector: "update:")
+            self.displayLink = CADisplayLink(target: self, selector: #selector(SkypeActionController.update(_:)))
             self.displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
         }
         animationCount++

--- a/Example/CustomActionControllers/Skype.swift
+++ b/Example/CustomActionControllers/Skype.swift
@@ -217,11 +217,11 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
             self.displayLink = CADisplayLink(target: self, selector: #selector(SkypeActionController.update(_:)))
             self.displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
         }
-        animationCount++
+        animationCount += 1
     }
     
     private func finishAnimation() {
-        animationCount--
+        animationCount -= 1
         if animationCount == 0 {
             displayLink.invalidate()
             displayLink = nil

--- a/Example/CustomActionControllers/Skype.swift
+++ b/Example/CustomActionControllers/Skype.swift
@@ -214,7 +214,7 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
     
     private func startAnimation() {
         if displayLink == nil {
-            self.displayLink = CADisplayLink(target: self, selector: #selector(SkypeActionController.update(_:)))
+            self.displayLink = CADisplayLink(target: self, selector: "update:")
             self.displayLink.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSDefaultRunLoopMode)
         }
         animationCount += 1

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -37,7 +37,7 @@ public struct Action<T> {
     public private(set) var data: T?
     public var enabled: Bool
     public private(set) var style = ActionStyle.Default
-    private (set) var handler: (Action<T> -> Void)?
+    public private (set) var handler: (Action<T> -> Void)?
 
     public init(_ data: T?, style: ActionStyle, handler: (Action<T> -> Void)?) {
         enabled = true

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -73,7 +73,7 @@ public enum HeaderSpec<HeaderType: UICollectionReusableView, HeaderDataType> {
 
 private enum ReusableViewIds: String {
     case Cell = "Cell"
-    case Header = "Heeder"
+    case Header = "Header"
     case SectionHeader = "SectionHeader"
 }
 

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -129,13 +129,13 @@ public class ActionController<ActionViewType: UICollectionViewCell, ActionDataTy
         collectionView.scrollEnabled = self.settings.behavior.scrollEnabled
         collectionView.showsVerticalScrollIndicator = false
         if self.settings.behavior.hideOnTap {
-            let tapRecognizer = UITapGestureRecognizer(target: self, action: "tapGestureDidRecognize:")
+            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(ActionController.tapGestureDidRecognize(_:)))
             collectionView.backgroundView = UIView(frame: collectionView.bounds)
             collectionView.backgroundView?.userInteractionEnabled = true
             collectionView.backgroundView?.addGestureRecognizer(tapRecognizer)
         }
         if self.settings.behavior.hideOnScrollDown && !self.settings.behavior.scrollEnabled {
-            let swipeGesture = UISwipeGestureRecognizer(target: self, action: "swipeGestureDidRecognize:")
+            let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(ActionController.swipeGestureDidRecognize(_:)))
             swipeGesture.direction = .Down
             collectionView.addGestureRecognizer(swipeGesture)
         }
@@ -266,7 +266,7 @@ public class ActionController<ActionViewType: UICollectionViewCell, ActionDataTy
                     cancel.backgroundColor = settings.cancelView.backgroundColor
                     let cancelButton: UIButton = {
                         let cancelButton = UIButton(frame: CGRectMake(0, 0, 100, settings.cancelView.height))
-                        cancelButton.addTarget(self, action: "cancelButtonDidTouch:", forControlEvents: .TouchUpInside)
+                        cancelButton.addTarget(self, action: #selector(ActionController.cancelButtonDidTouch(_:)), forControlEvents: .TouchUpInside)
                         cancelButton.setTitle(settings.cancelView.title, forState: .Normal)
                         cancelButton.translatesAutoresizingMaskIntoConstraints = false
                         return cancelButton

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -129,13 +129,13 @@ public class ActionController<ActionViewType: UICollectionViewCell, ActionDataTy
         collectionView.scrollEnabled = self.settings.behavior.scrollEnabled
         collectionView.showsVerticalScrollIndicator = false
         if self.settings.behavior.hideOnTap {
-            let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(ActionController.tapGestureDidRecognize(_:)))
+            let tapRecognizer = UITapGestureRecognizer(target: self, action: "tapGestureDidRecognize:")
             collectionView.backgroundView = UIView(frame: collectionView.bounds)
             collectionView.backgroundView?.userInteractionEnabled = true
             collectionView.backgroundView?.addGestureRecognizer(tapRecognizer)
         }
         if self.settings.behavior.hideOnScrollDown && !self.settings.behavior.scrollEnabled {
-            let swipeGesture = UISwipeGestureRecognizer(target: self, action: #selector(ActionController.swipeGestureDidRecognize(_:)))
+            let swipeGesture = UISwipeGestureRecognizer(target: self, action: "swipeGestureDidRecognize:")
             swipeGesture.direction = .Down
             collectionView.addGestureRecognizer(swipeGesture)
         }
@@ -266,7 +266,7 @@ public class ActionController<ActionViewType: UICollectionViewCell, ActionDataTy
                     cancel.backgroundColor = settings.cancelView.backgroundColor
                     let cancelButton: UIButton = {
                         let cancelButton = UIButton(frame: CGRectMake(0, 0, 100, settings.cancelView.height))
-                        cancelButton.addTarget(self, action: #selector(ActionController.cancelButtonDidTouch(_:)), forControlEvents: .TouchUpInside)
+                        cancelButton.addTarget(self, action: "cancelButtonDidTouch:", forControlEvents: .TouchUpInside)
                         cancelButton.setTitle(settings.cancelView.title, forState: .Normal)
                         cancelButton.translatesAutoresizingMaskIntoConstraints = false
                         return cancelButton


### PR DESCRIPTION
—Use APIs compatible with Swift 2.1
—Fix an issue where "Header" was spelled "Heeder"