### PR TITLE
Execute action's handler after VC is dismissed

### DIFF
--- a/Example/CustomActionControllers/Skype.swift
+++ b/Example/CustomActionControllers/Skype.swift
@@ -73,7 +73,7 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
         settings.animation.present.springVelocity = 0.0
         settings.animation.present.damping = 0.7
         settings.statusBar.style = .Default
-        
+
         onConfigureCellForAction = { cell, action, indexPath in
             cell.actionTitleLabel.text = action.data
             cell.actionTitleLabel.textColor = .whiteColor()
@@ -183,7 +183,7 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
         animator.addBehavior(gravityBehavior)
     }
     
-    //MARK : Private Helpers
+    // MARK: - Private Helpers
     
     private var diff = CGFloat(0)
     private var displayLink: CADisplayLink!
@@ -192,17 +192,15 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
     private lazy var animator: UIDynamicAnimator = { [unowned self] in
         let animator = UIDynamicAnimator(referenceView: self.view)
         return animator
-        }()
+    }()
     
     private lazy var gravityBehavior: UIGravityBehavior = { [unowned self] in
         let gravityBehavior = UIGravityBehavior(items: [self.collectionView])
         gravityBehavior.magnitude = 2.0
         return gravityBehavior
-        }()
-    
-    
+    }()
+
     @objc private func update(displayLink: CADisplayLink) {
-        
         let normalRectLayer = normalAnimationRect.layer.presentationLayer()
         let springRectLayer = springAnimationRect.layer.presentationLayer()
         
@@ -227,7 +225,6 @@ public class SkypeActionController: ActionController<SkypeCell, String, UICollec
             displayLink = nil
         }
     }
-    
     
     private class ContextView: UIView {
         let topSpace = CGFloat(25)

--- a/Example/SkypeExampleViewController.swift
+++ b/Example/SkypeExampleViewController.swift
@@ -26,7 +26,7 @@ import UIKit
 import XLActionController
 
 class SkypeExampleViewController: UIViewController {
-    
+
     override func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(true, animated: animated)
@@ -35,11 +35,9 @@ class SkypeExampleViewController: UIViewController {
     @IBAction func backButtonDidTouch(sender: UIButton) {
         navigationController?.popViewControllerAnimated(true)
     }
-    
+
     @IBAction func tapGestureDidRecognize(sender: UITapGestureRecognizer) {
-        
         let actionController = SkypeActionController()
-        
         actionController.addAction(Action("Take photo", style: .Default, handler: { action in
         }))
         actionController.addAction(Action("Choose existing photo", style: .Default, handler: { action in
@@ -47,8 +45,8 @@ class SkypeExampleViewController: UIViewController {
         actionController.addAction(Action("Remove profile picture", style: .Default, handler: { action in
         }))
         actionController.addAction(Action("Cancel", style: .Cancel, handler: nil))
-        
+
         presentViewController(actionController, animated: true, completion: nil)
-        
     }
+
 }

--- a/Example/TweetbotExampleViewController.swift
+++ b/Example/TweetbotExampleViewController.swift
@@ -49,7 +49,7 @@ class TweetBotExampleViewController: UIViewController {
         }))
         actionController.addAction(Action("View in Favstar", style: .Default, handler: { action in
         }))
-        actionController.addAction(Action("Translate", style: .Default, handler: { action in
+        actionController.addAction(Action("Translate", style: .Default, executeImmediatelyOnTouch: true, handler: { action in
         }))
         actionController.addSection(Section())
         actionController.addAction(Action("Cancel", style: .Cancel, handler:nil))

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ actionController.addAction(Action("View Retweets", style: .Default, handler: { a
 actionController.addAction(Action("View in Favstar", style: .Default, handler: { action in
   // do something useful
 }))
-actionController.addAction(Action("Translate", style: .Default, handler: { action in
+actionController.addAction(Action("Translate", style: .Default, executeImmediatelyOnTouch: true, handler: { action in
   // do something useful
 }))
 
@@ -69,6 +69,8 @@ presentViewController(actionController, animated: true, completion: nil)
 ```
 
 As you may have noticed, the library usage looks pretty similar to UIAlertController.
+
+Actions' handlers are executed after the alert controller is dismissed from screen. If you want, you can change this passing `true` to the action's constructor to the argument `executeImmediatelyOnTouch`.
 
 > Behind the scenes XLActionController uses a UICollectionView to display the action sheet.
 

--- a/Source/Action.swift
+++ b/Source/Action.swift
@@ -34,15 +34,19 @@ public enum ActionStyle {
 
 public struct Action<T> {
 
-    public private(set) var data: T?
     public var enabled: Bool
-    public private(set) var style = ActionStyle.Default
-    public private (set) var handler: (Action<T> -> Void)?
+    public var executeImmediatelyOnTouch = false
 
-    public init(_ data: T?, style: ActionStyle, handler: (Action<T> -> Void)?) {
+    public private(set) var data: T?
+    public private(set) var style = ActionStyle.Default
+    public private(set) var handler: (Action<T> -> Void)?
+
+    public init(_ data: T?, style: ActionStyle, executeImmediatelyOnTouch: Bool = false, handler: (Action<T> -> Void)?) {
         enabled = true
+        self.executeImmediatelyOnTouch = executeImmediatelyOnTouch
         self.data = data
         self.style = style
         self.handler = handler
     }
+
 }

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -201,7 +201,11 @@ public class ActionController<ActionViewType: UICollectionViewCell, ActionDataTy
     }
     
     public func dismiss() {
-        self.presentingViewController?.dismissViewControllerAnimated(true, completion: nil)
+        dismiss(nil)
+    }
+
+    public func dismiss(completion: (() -> ())?) {
+        self.presentingViewController?.dismissViewControllerAnimated(true, completion: completion)
     }
     
     // MARK: - View controller behavior
@@ -378,10 +382,17 @@ public class ActionController<ActionViewType: UICollectionViewCell, ActionDataTy
     }
     
     public func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-        if let action = self.actionForIndexPath(actionIndexPathFor(indexPath)) {
+        let action = self.actionForIndexPath(actionIndexPathFor(indexPath))
+
+        if let action = action where action.executeImmediatelyOnTouch {
             action.handler?(action)
         }
-        self.dismiss()
+
+        self.dismiss() {
+            if let action = action where !action.executeImmediatelyOnTouch {
+                action.handler?(action)
+            }
+        }
     }
 
     public func collectionView(collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAtIndexPath indexPath: NSIndexPath) -> CGSize {
@@ -714,4 +725,5 @@ public class DynamicsActionController<ActionViewType: UICollectionViewCell, Acti
     public override func performCustomDismissingAnimation(presentedView: UIView, presentingView: UIView) {
         // Nothing to do in this case
     }
+
 }


### PR DESCRIPTION
Fixes issue #20.

Action controller's behavior is changed in order to execute actions' handler after the controller is dismissed from screen. This will end in a better transition flow when the action takes the user to another screen.

There are circumstances where developers may want modify this behavior for an specific action. In order to allow developers to use the most appropriate behavior, a new property `executeImmediatelyOnTouch` was added to the `Action` class.  

From now, developers are allowed to change the behavior of an action by setting it when creating the action or modifying the value of the new property.

```swift
// Instanciate a new action, which handler will be fired after the alert controller has been dismissed
let action = Action("Translate", style: .Default, executeImmediatelyOnTouch: true, handler: { action in
}))

// Later, you can change the behavior of the action
action.executeImmediatelyOnTouch = false
```

**Note**: this might break some existing app. Developers can fix it by setting `true` to the new property added

-- edited --

Plus: added a fix to issue #10 