### PR TITLE
Fixes #12 by removing specific constraint code

### DIFF
--- a/Example/CustomActionControllers/PeriscopeCell.xib
+++ b/Example/CustomActionControllers/PeriscopeCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -14,25 +14,21 @@
                 <rect key="frame" x="0.0" y="0.0" width="500" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Action title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="amS-Rr-sbk">
-                        <rect key="frame" x="25" y="21" width="451" height="19"/>
-                        <animations/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" misplaced="YES" text="Action title" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="amS-Rr-sbk">
+                        <rect key="frame" x="25" y="21" width="451" height="20"/>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xHC-6U-E5A">
                         <rect key="frame" x="0.0" y="59" width="500" height="1"/>
-                        <animations/>
                         <color key="backgroundColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="0.5" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="dEF-lq-7gy"/>
                         </constraints>
                     </view>
                 </subviews>
-                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
-            <animations/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="fOL-sM-c6E" secondAttribute="leading" constant="25" id="7lg-lz-nVw"/>

--- a/Example/CustomActionControllers/Twitter.swift
+++ b/Example/CustomActionControllers/Twitter.swift
@@ -28,7 +28,9 @@ import XLActionController
 #endif
 
 public class TwitterCell: ActionCell {
-    
+
+    @IBOutlet weak var imageViewWidthConstraint: NSLayoutConstraint!
+
     public override init(frame: CGRect) {
         super.init(frame: frame)
         initialize()
@@ -42,7 +44,15 @@ public class TwitterCell: ActionCell {
         super.awakeFromNib()
         initialize()
     }
-    
+
+    public override func setup(title: String?, detail: String?, image: UIImage?) {
+        super.setup(title, detail: detail, image: image)
+
+        imageViewWidthConstraint.constant = image == nil ? 0 : 36
+
+        setNeedsLayout()
+    }
+
     func initialize() {
         backgroundColor = .whiteColor()
         actionImageView?.clipsToBounds = true
@@ -102,7 +112,6 @@ public class TwitterActionController: ActionController<TwitterCell, ActionData, 
             header.label.text = title
         }
         onConfigureCellForAction = { [weak self] cell, action, indexPath in
-            
             cell.setup(action.data?.title, detail: action.data?.subtitle, image: action.data?.image)
             cell.separatorView?.hidden = indexPath.item == (self?.collectionView.numberOfItemsInSection(indexPath.section))! - 1
             cell.alpha = action.enabled ? 1.0 : 0.5

--- a/Example/CustomActionControllers/TwitterCell.xib
+++ b/Example/CustomActionControllers/TwitterCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -17,7 +16,6 @@
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xHC-6U-E5A">
                         <rect key="frame" x="0.0" y="55" width="500" height="1"/>
-                        <animations/>
                         <color key="backgroundColor" red="0.80000000000000004" green="0.80000000000000004" blue="0.80000000000000004" alpha="0.5" colorSpace="calibratedRGB"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="1" id="dEF-lq-7gy"/>
@@ -25,39 +23,26 @@
                     </view>
                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="aVP-K2-xfz">
                         <rect key="frame" x="10" y="10" width="36" height="36"/>
-                        <animations/>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="22" id="FhR-W3-1Bu"/>
-                            <constraint firstAttribute="width" secondItem="aVP-K2-xfz" secondAttribute="height" multiplier="1:1" id="aTy-zU-kfl"/>
+                            <constraint firstAttribute="height" constant="36" id="4by-Mh-UIp"/>
                             <constraint firstAttribute="width" constant="36" id="lwu-fc-evQ"/>
-                            <constraint firstAttribute="height" constant="36" id="o7S-aU-N1A"/>
                         </constraints>
-                        <variation key="default">
-                            <mask key="constraints">
-                                <exclude reference="FhR-W3-1Bu"/>
-                                <exclude reference="aTy-zU-kfl"/>
-                            </mask>
-                        </variation>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Action title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="amS-Rr-sbk">
-                        <rect key="frame" x="56" y="10" width="419" height="20.5"/>
-                        <animations/>
+                        <rect key="frame" x="56" y="10" width="419" height="20"/>
                         <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Detail" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="ioD-CX-YYA" userLabel="Detail Label">
-                        <rect key="frame" x="56" y="30" width="419" height="15.5"/>
-                        <animations/>
+                        <rect key="frame" x="56" y="30" width="419" height="16"/>
                         <fontDescription key="fontDescription" type="system" pointSize="13"/>
                         <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
-            <animations/>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="xHC-6U-E5A" secondAttribute="trailing" id="AqN-WS-4KQ"/>
@@ -67,21 +52,20 @@
                 <constraint firstAttribute="bottom" secondItem="aVP-K2-xfz" secondAttribute="bottom" constant="10" id="Mli-V6-r1P"/>
                 <constraint firstItem="ioD-CX-YYA" firstAttribute="trailing" secondItem="amS-Rr-sbk" secondAttribute="trailing" id="QV3-aH-Mw3"/>
                 <constraint firstItem="ioD-CX-YYA" firstAttribute="leading" secondItem="amS-Rr-sbk" secondAttribute="leading" id="SvK-a2-wct"/>
-                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="fOL-sM-c6E" secondAttribute="leading" priority="750" constant="25" id="bLX-R3-Jyl"/>
+                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fOL-sM-c6E" secondAttribute="leading" constant="25" id="bLX-R3-Jyl"/>
                 <constraint firstItem="xHC-6U-E5A" firstAttribute="leading" secondItem="fOL-sM-c6E" secondAttribute="leading" id="enj-es-v6l"/>
                 <constraint firstItem="aVP-K2-xfz" firstAttribute="top" secondItem="fOL-sM-c6E" secondAttribute="top" constant="10" id="fBY-cv-M8W"/>
                 <constraint firstItem="aVP-K2-xfz" firstAttribute="leading" secondItem="fOL-sM-c6E" secondAttribute="leading" constant="10" id="oON-tj-kmP"/>
                 <constraint firstAttribute="bottom" secondItem="xHC-6U-E5A" secondAttribute="bottom" id="rTT-j0-6wy"/>
                 <constraint firstItem="ioD-CX-YYA" firstAttribute="bottom" secondItem="aVP-K2-xfz" secondAttribute="bottom" id="uzx-HX-7dU"/>
-                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="aVP-K2-xfz" secondAttribute="trailing" constant="10" id="zB0-b4-ivL"/>
+                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="aVP-K2-xfz" secondAttribute="trailing" priority="750" constant="10" id="zB0-b4-ivL"/>
             </constraints>
             <size key="customSize" width="500" height="131"/>
             <connections>
                 <outlet property="actionDetailLabel" destination="ioD-CX-YYA" id="AOP-7m-ePg"/>
                 <outlet property="actionImageView" destination="aVP-K2-xfz" id="bKM-4f-Zqg"/>
                 <outlet property="actionTitleLabel" destination="amS-Rr-sbk" id="3gI-J0-QKK"/>
-                <outlet property="actionTitleLabelConstraintToContainer" destination="bLX-R3-Jyl" id="Bqh-9k-tNf"/>
-                <outlet property="actionTitleLabelConstraintToImageView" destination="zB0-b4-ivL" id="jvC-Ih-A3F"/>
+                <outlet property="imageViewWidthConstraint" destination="lwu-fc-evQ" id="MYk-pO-pdn"/>
                 <outlet property="separatorView" destination="xHC-6U-E5A" id="Zvp-2G-WIU"/>
             </connections>
             <point key="canvasLocation" x="307" y="109"/>

--- a/Example/CustomActionControllers/YoutubeCell.xib
+++ b/Example/CustomActionControllers/YoutubeCell.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9059" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9049"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
@@ -17,7 +17,6 @@
                 <subviews>
                     <imageView userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="aVP-K2-xfz">
                         <rect key="frame" x="10" y="3" width="40" height="40"/>
-                        <animations/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="22" id="FhR-W3-1Bu"/>
                             <constraint firstAttribute="width" secondItem="aVP-K2-xfz" secondAttribute="height" multiplier="1:1" id="aTy-zU-kfl"/>
@@ -32,31 +31,26 @@
                         </variation>
                     </imageView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Action title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="amS-Rr-sbk">
-                        <rect key="frame" x="60" y="13.5" width="415" height="19.5"/>
-                        <animations/>
+                        <rect key="frame" x="60" y="13" width="415" height="20"/>
                         <fontDescription key="fontDescription" type="system" pointSize="16"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
-                <animations/>
                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
             </view>
-            <animations/>
             <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="amS-Rr-sbk" secondAttribute="trailing" constant="25" id="L4t-D4-7g4"/>
-                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="fOL-sM-c6E" secondAttribute="leading" priority="750" constant="25" id="bLX-R3-Jyl"/>
+                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="fOL-sM-c6E" secondAttribute="leading" constant="25" id="bLX-R3-Jyl"/>
                 <constraint firstItem="aVP-K2-xfz" firstAttribute="centerY" secondItem="fOL-sM-c6E" secondAttribute="centerY" id="eQb-CS-5ZR"/>
                 <constraint firstItem="amS-Rr-sbk" firstAttribute="centerY" secondItem="fOL-sM-c6E" secondAttribute="centerY" id="gZn-Wf-2oH"/>
                 <constraint firstItem="aVP-K2-xfz" firstAttribute="leading" secondItem="fOL-sM-c6E" secondAttribute="leading" constant="10" id="oON-tj-kmP"/>
-                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="aVP-K2-xfz" secondAttribute="trailing" constant="10" id="zB0-b4-ivL"/>
+                <constraint firstItem="amS-Rr-sbk" firstAttribute="leading" secondItem="aVP-K2-xfz" secondAttribute="trailing" priority="750" constant="10" id="zB0-b4-ivL"/>
             </constraints>
             <size key="customSize" width="500" height="131"/>
             <connections>
                 <outlet property="actionImageView" destination="aVP-K2-xfz" id="bKM-4f-Zqg"/>
                 <outlet property="actionTitleLabel" destination="amS-Rr-sbk" id="3gI-J0-QKK"/>
-                <outlet property="actionTitleLabelConstraintToContainer" destination="bLX-R3-Jyl" id="Bqh-9k-tNf"/>
-                <outlet property="actionTitleLabelConstraintToImageView" destination="zB0-b4-ivL" id="jvC-Ih-A3F"/>
             </connections>
             <point key="canvasLocation" x="307" y="109"/>
         </collectionViewCell>

--- a/Source/ActionCell.swift
+++ b/Source/ActionCell.swift
@@ -40,20 +40,7 @@ public class ActionCell: UICollectionViewCell, SeparatorCellType {
         actionTitleLabel?.text = title
         actionDetailLabel?.text = detail
         actionImageView?.image = image
-
-        if let _ = image {
-            actionTitleLabelConstraintToContainer?.priority = UILayoutPriorityDefaultHigh
-            actionTitleLabelConstraintToImageView?.priority = UILayoutPriorityRequired
-        } else {
-            actionTitleLabelConstraintToContainer?.priority = UILayoutPriorityRequired
-            actionTitleLabelConstraintToImageView?.priority = UILayoutPriorityDefaultHigh
-        }
     }
-    
-    
-    @IBOutlet private weak var actionTitleLabelConstraintToContainer: NSLayoutConstraint?
-    @IBOutlet private weak var actionTitleLabelConstraintToImageView: NSLayoutConstraint?
-    
     
     public func showSeparator() {
         separatorView?.alpha = 1.0


### PR DESCRIPTION
Fixes issue #12.

The crash is caused because `ActionCell` is changing the priority from some constraints from Required to Optional and viceversa when they are already installed. This can happen when the `setup` method is called twice, and the second time passing a null image. These constraints control how the cell's title label is positioned taking into account if the cell has or not an image.

I just removed these constraint from the base class `ActionCell` instead of trying to change the constraints properties in some way. I opted for removing them because they add specific dependent  code on how the cell's UI is designed and should be out of the scope of this class. This way we are avoiding coupling XLActionController base code with specific actions' UI code.

>To see how this can be implemented, developers can take a look to TwitterCell

Note: this is a breaking change. If this PR is merged then, **apps that are using these constraint it will crash with the exception** "this class is not key value coding-compliant for the key..."

```
2016-09-05 14:44:22.837 Example[6518:267146] *** Terminating app due to uncaught exception 'NSUnknownKeyException', reason: '[<Example.YoutubeCell 0x7fc469e62320> setValue:forUndefinedKey:]: this class is not key value coding-compliant for the key actionTitleLabelConstraintToContainer.'
```
