### PR TITLE
Call dismissView completion closure when animation is finished

### DIFF
--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -514,12 +514,8 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
             },
             completion: { [weak self] _ in
                 self?.onDidDismissView()
+                completion?(true)
             })
-
-        let delayTime = DispatchTime.now() + Double(Int64(animationDuration * 0.25 * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
-        DispatchQueue.main.asyncAfter(deadline: delayTime) {
-            completion?(true)
-        }
     }
     
     open func onWillPresentView() {


### PR DESCRIPTION
Previously the completion closure was being called after a manually-calculated time delay. This was causing the completion handler to be called slightly early, resulting in the action sheet abruptly popping off-screen without finishing the animation. This was especially noticeable with slow animations enabled, as the extended animation duration was not accounted for.

I've fixed this by calling the completion closure from the animation's completion closure. Was there a specific reason it was being called after a manually-calculated delay?