### PR TITLE
Added property to control if collection view is covered by cancelView

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,8 +316,9 @@ settings.cancelView.title: String?
 settings.cancelView.height: CGFloat
  // Cancel view's background color. `UIColor.black.withAlphaComponent(0.8)` by default.
 settings.cancelView.backgroundColor: UIColor
+// Indicates if the collection view is partially hidden by the cancelView when it is pulled down.
+settings.cancelView.hideCollectionViewBehindCancelView: Bool
 ```
-
 
 ### Advanced animations
 

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -259,8 +259,12 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
             let lastSectionIndex = _sections.count - 1
             let layoutAtts = collectionViewLayout.layoutAttributesForItem(at: IndexPath(item: section.actions.count - 1, section: hasHeader() ? lastSectionIndex + 1 : lastSectionIndex))
             contentHeight = layoutAtts!.frame.origin.y + layoutAtts!.frame.size.height
+
+            if settings.cancelView.showCancel && !settings.cancelView.hideCollectionViewBehindCancelView {
+                contentHeight += settings.cancelView.height
+            }
         }
-        
+
         setUpContentInsetForHeight(view.frame.height)
         
         // set up collection view initial position taking into account top content inset

--- a/Source/ActionControllerSettings.swift
+++ b/Source/ActionControllerSettings.swift
@@ -76,6 +76,11 @@ public struct ActionControllerSettings {
          * The cancel view's background color. Its default value is `UIColor.blackColor().colorWithAlphaComponent(0.8)`.
          */
         public var backgroundColor = UIColor.black.withAlphaComponent(0.8)
+        /**
+          * A Boolean value that determines whether the collection view can be partially covered by the 
+          * cancel view when it is pulled down. Its default value is `true`
+          */
+        public var hideCollectionViewBehindCancelView = true
     }
 
     /** Struct that contains properties to configure the collection view's style */


### PR DESCRIPTION
In order to fix issue #34, a new property `hideCollectionViewBehindCancelView` is being added to the action controller settings struct.

This new property allows developers to change whether the collection view should be hidden behind `cancelView` when pulled down. This property is taken into account when calculating the collection view's contentHeight only if `settings.cancelView.showCancel` is `true`.

By default, `hideCollectionViewBehindCancelView` value is `true` so everything will continue working as before. To prevent collection view being hidden behind `cancelView`, you have to set this property to `false`.
