### PR TITLE
Fixed #36: overriding missing dismiss function

### DIFF
--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -698,15 +698,19 @@ open class DynamicsActionController<ActionViewType: UICollectionViewCell, Action
     }
 
     // MARK: - Overrides
-    
+
     open override func dismiss() {
+        dismiss(nil)
+    }
+
+    open override func dismiss(_ completion: (() -> ())?) {
         animator.addBehavior(gravityBehavior)
-        
+
         UIView.animate(withDuration: settings.animation.dismiss.duration, animations: { [weak self] in
             self?.backgroundView.alpha = 0.0
-        }) 
-        
-        presentingViewController?.dismiss(animated: true, completion: nil)
+        })
+
+        presentingViewController?.dismiss(animated: true, completion: completion)
     }
 
     open override func dismissView(_ presentedView: UIView, presentingView: UIView, animationDuration: Double, completion: ((_ completed: Bool) -> Void)?) {


### PR DESCRIPTION
Issue #36, was caused because the class `DynamicsActionController` didn't override the function `dismiss(completion: (() -> ())?)` which is called from `ActionController`when an collection view item is selected. Then the action controller was dismissed using the base animation instead of the UI Dynamic animator.

Adding an override for `dismiss(completion: (() -> ())?)` that calls the completion callback after the action controller is dismissed solves the problem.