### PR TITLE
Using status bar style from settings in iOS 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ### master branch
 
+* Using status bar style from settings in iOS 10, [PR #53](https://github.com/xmartlabs/XLActionController/pull/53) 
+
 ### [3.0.1](https://github.com/xmartlabs/XLActionController/releases/tag/3.0.1)
 
 * Fixed crash when using ActionCell.xib, [PR #31](https://github.com/xmartlabs/XLActionController/pull/31).

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ settings.animation.dismiss.options: UIViewAnimationOptions
 settings.statusBar.showStatusBar: Bool
 // Determines the style of the device’s status bar when the action controller is visible. `UIStatusBarStyle.LightContent` by default.
 settings.statusBar.style: UIStatusBarStyle
+// Determines whether the action controller takes over control of status bar appearance from the presenting view controller. `true` by default.
+settings.statusBar.modalPresentationCapturesStatusBarAppearance: Bool
 ```
 
 #### Cancel view style

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -220,6 +220,8 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
     open override func viewDidLoad() {
         super.viewDidLoad()
 
+        modalPresentationCapturesStatusBarAppearance = settings.statusBar.modalPresentationCapturesStatusBarAppearance
+
         // background view
         view.addSubview(backgroundView)
 

--- a/Source/ActionControllerSettings.swift
+++ b/Source/ActionControllerSettings.swift
@@ -184,6 +184,14 @@ public struct ActionControllerSettings {
          * default value is `UIStatusBarStyle.LightContent`.
          */
         public var style = UIStatusBarStyle.lightContent
+        /**
+         * A boolean value that determines whether the action controller takes over control of status bar appearance from the presenting 
+         * view controller. Its default value is `true`.
+         *
+         * For more information refer to `UIViewController.modalPresentationCapturesStatusBarAppearance`, 
+         * https://developer.apple.com/reference/uikit/uiviewcontroller/1621453-modalpresentationcapturesstatusb
+         */
+        public var modalPresentationCapturesStatusBarAppearance = true
     }
     
     /** Stores the behavior's properties values */


### PR DESCRIPTION
The property `modalPresentationCapturesStatusBarAppearance` must be set to `true` in order to let a presented action controller to take control over the status bar style. A new property with the same name was added to the `ActionControllerSettings` struct to let users change its behavior. 

By default this new property is set to `true` so presented action controllers always will apply their status bar style (defined in the `settings` property).

Fix #43 

![status_bar_style](https://cloud.githubusercontent.com/assets/4791678/25502208/1f58d67c-2b6c-11e7-9de3-431c3ea77f2c.gif)
