### PR TITLE
Fixes #75: crash on iOS 11 using dynamics

### DIFF
--- a/Source/DynamicCollectionViewFlowLayout.swift
+++ b/Source/DynamicCollectionViewFlowLayout.swift
@@ -89,8 +89,9 @@ open class DynamicCollectionViewFlowLayout: UICollectionViewFlowLayout {
         guard let animator = dynamicAnimator else {
             return super.layoutAttributesForElements(in: rect)
         }
-        
-        return animator.items(in: rect) as? [UICollectionViewLayoutAttributes]
+
+        let items = animator.items(in: rect) as NSArray
+        return items.flatMap { $0 as? UICollectionViewLayoutAttributes }
     }
     
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {


### PR DESCRIPTION
Solve a crash due to an issue on UIDynamicAnimator (Filed with Apple, radar 33979954.)
The solution was proposed in #75.