### PR TITLE
Fixes #64: allow to hide nav bar when presenting controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,8 @@ settings.behavior.scrollEnabled: Bool
 settings.behavior.bounces: Bool
 // Indicates if the collection view layout will use UIDynamics to animate its items. `false` by default.
 settings.behavior.useDynamics: Bool
+// Determines whether the navigation bar is hidden when action controller is being presented. `true` by default
+settings.hideCollectionViewBehindCancelView: Bool
 ```
 
 #### UICollectionView Style

--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -151,7 +151,11 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
         collectionViewLayout.minimumLineSpacing = 0
         return collectionViewLayout
     }()
-    
+
+    open var presentingNavigationController: UINavigationController? {
+        return (presentingViewController as? UINavigationController) ?? presentingViewController?.navigationController
+    }
+
     // MARK: - ActionController initializers
     
     public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
@@ -301,6 +305,18 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         backgroundView.frame = view.bounds
+
+        if let navController = presentingNavigationController, settings.behavior.hideNavigationBarOnShow {
+            navigationBarWasHiddenAtStart = navController.isNavigationBarHidden
+            navController.setNavigationBarHidden(true, animated: animated)
+        }
+    }
+
+    open override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        if let navController = presentingNavigationController, settings.behavior.hideNavigationBarOnShow {
+            navController.setNavigationBarHidden(navigationBarWasHiddenAtStart, animated: animated)
+        }
     }
 
     open override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -622,6 +638,7 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
 
     // MARK: - Private properties
 
+    fileprivate var navigationBarWasHiddenAtStart = false
     fileprivate var disableActions = false
     fileprivate var isPresenting = false
 

--- a/Source/ActionControllerSettings.swift
+++ b/Source/ActionControllerSettings.swift
@@ -55,6 +55,11 @@ public struct ActionControllerSettings {
          * items. Its default value is `false`
          */
         public var useDynamics = false
+        /**
+         * A Boolean value that determines whether the navigation bar will hide when action controller is being
+         * presented. Its default value is `true`
+         */
+        public var hideNavigationBarOnShow = true
     }
     
     /** Struct that contains properties to configure the cancel view */


### PR DESCRIPTION
Added property `hideNavigationBarOnShow` to configure whether action controller hides navigation bar (if present) when it is being shown. The new property's default value is `true`

This change addresses issue #64.

| Issue | Solved |
| ----- | ------- |
| ![#64-issue](https://user-images.githubusercontent.com/4791678/33918649-549216f6-df93-11e7-8a37-a198df29cace.gif) | ![#64-solved](https://user-images.githubusercontent.com/4791678/33918739-e0c27080-df93-11e7-8b5d-a55a0d57f28a.gif) |


