### PR TITLE
Segmentation fault 11 in XCode 9.3.1

### DIFF
--- a/Example/CustomActionControllers/Skype.swift
+++ b/Example/CustomActionControllers/Skype.swift
@@ -223,8 +223,8 @@ open class SkypeActionController: ActionController<SkypeCell, String, UICollecti
         let normalRectLayer = normalAnimationRect.layer.presentation()
         let springRectLayer = springAnimationRect.layer.presentation()
         
-        guard let normalRectFrame = (normalRectLayer?.value(forKey: "frame") as AnyObject).cgRectValue,
-          let springRectFrame = (springRectLayer?.value(forKey: "frame") as AnyObject).cgRectValue else {
+        guard let normalRectFrame = normalRectLayer?.frame,
+          let springRectFrame = springRectLayer?.frame else {
             return
         }
         contextView.diff = normalRectFrame.origin.y - springRectFrame.origin.y


### PR DESCRIPTION
Fixed a Segmentation fault 11 in XCode 9.3.1 due to a compilation error while converting .value("frame") into a cgRect

In XCode 9.3.1, swift 4 :
`(normalRectLayer?.value(forKey: "frame") as AnyObject).cgRectValue
`
Proposed fix :
`normalRectLayer?.frame
`
I was just testing this Skype Example but maybe other example have this issue as well...