### PR TITLE
Fix incorrect top inset and content offset

### DIFF
--- a/Source/ActionController.swift
+++ b/Source/ActionController.swift
@@ -667,20 +667,15 @@ open class ActionController<ActionViewType: UICollectionViewCell, ActionDataType
         var bottomInset = settings.cancelView.showCancel ? initialContentInset.bottom + settings.cancelView.height : initialContentInset.bottom
         var topInset = height - contentHeight - safeAreaInsets.bottom
 
-        if settings.cancelView.showCancel {
-            topInset -= settings.cancelView.height
-        }
-
-        topInset = max(topInset, 30)
+        topInset = max(topInset, safeAreaInsets.top + 30)
 
         bottomInset += safeAreaInsets.bottom
         leftInset += safeAreaInsets.left
         rightInset += safeAreaInsets.right
-        topInset += safeAreaInsets.top
 
         collectionView.contentInset = UIEdgeInsets(top: topInset, left: leftInset, bottom: bottomInset, right: rightInset)
         if !settings.behavior.useDynamics {
-            collectionView.contentOffset.y = -height + contentHeight + bottomInset
+            collectionView.contentOffset.y = -topInset
         }
     }
 

--- a/Source/DynamicCollectionViewFlowLayout.swift
+++ b/Source/DynamicCollectionViewFlowLayout.swift
@@ -176,7 +176,6 @@ open class DynamicCollectionViewFlowLayout: UICollectionViewFlowLayout {
         }
 
         frame.origin.x = translationX
-        frame.origin.y -= collectionView.contentInset.bottom
         initialFrame.origin.x = translationX
 
         let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)


### PR DESCRIPTION
> If you'd like to test the effect it cases, just simply delete any 4 of 5 actions in `SpotifyExampleViewController` and then run it. Then drag down the view. The action cells are covered by the cancel view even the `hideCollectionViewBehindCancelView` is `true`.
When setting the `hideCollectionViewBehindCancelView` to `false` in `SpotifyActionController`. The effect is more obvious than the fist one. The initial offset is messed up.

This pr fix several issues about top inset and content offset:

1. `contentHeight` already contains the cancelView's `height` when it calculated in `viewDidLoad`. So there is no need to minus it _again_.
2. The minimum top inset is `safeAreaInsets.top + 30`. In other words, if the top inset is already greater than the minimum number, it should not plus the top value.
3. As mentioned above, `contentHeight` contains cancelView's `height`, and `bottomInset` contains the height as well, which case the incorrect initial content offset.